### PR TITLE
feat: injectable snippet (v0-6-0) — openspec proposal

### DIFF
--- a/openspec/changes/v0-6-0-injectable-snippet/.openspec.yaml
+++ b/openspec/changes/v0-6-0-injectable-snippet/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-09

--- a/openspec/changes/v0-6-0-injectable-snippet/design.md
+++ b/openspec/changes/v0-6-0-injectable-snippet/design.md
@@ -1,0 +1,119 @@
+## Context
+
+Feedtack's capture logic (`src/capture/target.ts`, `src/capture/meta.ts`) is already framework-agnostic — it reads DOM attributes, computes selectors, and collects viewport/device metadata. The React layer (`src/react/`) wraps this in hooks and components. The injectable snippet needs to reuse the capture layer but provide its own UI and egress, independent of React.
+
+The existing build produces ESM/CJS modules via tsup. The snippet needs a single IIFE file that can be pasted raw or loaded via a bookmarklet.
+
+## Goals / Non-Goals
+
+**Goals:**
+- A single JS file that works when pasted into any browser console or loaded as a bookmarklet
+- Same payload schema as the React version (full interop)
+- Zero-config clipboard mode and optional webhook mode
+- Interactive docs page where users generate their configured snippet
+- Under 20KB minified
+
+**Non-Goals:**
+- Content approval/editing — feedback-only
+- Persistent feedback list / inbox UI — submit and forget
+- Server-side rendering or SSR compatibility
+- Thread/reply support — single submissions only
+- Screenshot capture
+
+## Decisions
+
+### 1. IIFE with inline styles, no external assets
+
+The snippet must be fully self-contained. All CSS is injected as inline styles or a single `<style>` element. No external fonts, icons, or stylesheets.
+
+**Alternative considered:** Loading a hosted CSS file. Rejected because it adds a network dependency and CORS issues on arbitrary sites.
+
+### 2. Two-mode egress: clipboard (default) vs webhook
+
+**Clipboard mode** (default): On submit, the payload JSON is copied to the clipboard via `navigator.clipboard.writeText()`. A toast confirms "Copied to clipboard." No server, no URL, no config. Falls back to `document.execCommand('copy')` if clipboard API is unavailable (non-HTTPS).
+
+**Webhook mode**: If a URL is provided at init time (`feedtack.inject({ url: '...' })`), payloads are sent via `navigator.sendBeacon(url, JSON.stringify(payload))`. sendBeacon is fire-and-forget, survives page unload, and doesn't block UI. Falls back to `fetch()` if sendBeacon is unavailable.
+
+**Alternative considered:** LocalStorage queue with export. Rejected — data would live on someone else's domain and requires a separate export step.
+
+### 3. Bookmarklet as a loader, not the full script
+
+The bookmarklet URL can't contain the full IIFE (URL length limits vary by browser, ~2KB is safe). Instead, the bookmarklet injects a `<script>` tag that loads the snippet from a CDN (unpkg/jsdelivr) or a user-provided URL:
+
+```
+javascript:void((function(){var s=document.createElement('script');s.src='https://unpkg.com/feedtack@latest/dist/feedtack.inject.js';document.head.appendChild(s)})())
+```
+
+For webhook mode, the bookmarklet sets a global config before loading:
+
+```
+javascript:void((function(){window.__feedtack_config={url:'https://...'};var s=document.createElement('script');s.src='...';document.head.appendChild(s)})())
+```
+
+The console paste version IS the full IIFE — no loader needed.
+
+### 4. UI structure
+
+Minimal floating UI in bottom-right corner, matching existing feedtack visual language:
+
+- **Trigger button**: Small floating button, `position: fixed`, bottom-right. Click toggles the panel.
+- **Panel**: Scope selector (site/page/element tabs), comment textarea, sentiment buttons (good/bad/none), submit button.
+- **Pin mode**: "Place a pin" button switches to crosshair cursor. Click on any element captures target. Pin indicator appears on element.
+- **Toast**: Confirmation message after submit (copied / sent).
+
+All UI lives inside a Shadow DOM host element to avoid CSS conflicts with the host page.
+
+### 5. Shadow DOM isolation
+
+The snippet creates a `<div id="feedtack-inject">` with an attached shadow root. All UI renders inside the shadow DOM. This prevents:
+- Host page CSS from affecting feedtack UI
+- Feedtack styles from leaking into the host page
+- ID/class collisions
+
+### 6. Reuse capture code via build-time bundling
+
+The IIFE bundles `src/capture/target.ts` and `src/capture/meta.ts` at build time. These modules are already React-free. tsup bundles them into the IIFE alongside the inject-specific UI code.
+
+Verify: `src/capture/index.ts` barrel must not re-export anything that pulls in React. Currently exports `scanFields` and `hashField` from `content.ts` which uses Web Crypto — fine, but not needed for the snippet. The IIFE entry point imports directly from `target.ts` and `meta.ts`.
+
+### 7. Build configuration
+
+New tsup entry point:
+
+```ts
+// tsup.config.ts — add entry
+{
+  entry: { 'feedtack.inject': 'src/inject/index.ts' },
+  format: ['iife'],
+  globalName: 'feedtack',
+  minify: true,
+  noExternal: [/.*/],  // bundle everything
+}
+```
+
+Output: `dist/feedtack.inject.js`
+
+Package.json export:
+```json
+"./inject": { "default": "./dist/feedtack.inject.js" }
+```
+
+### 8. Snippet builder docs page
+
+React component at `site-docs/content/docs/guides/snippet.mdx` with an interactive client component:
+
+- Text input for webhook URL (optional)
+- Toggle for clipboard vs webhook mode
+- Generated bookmarklet: renders as a draggable `<a href="javascript:...">` link
+- Generated console snippet: copyable code block with the full IIFE
+- Preview of what the snippet does (static screenshot or description)
+
+The component is a client-side React component in the docs site — it generates the bookmarklet/snippet strings dynamically based on user input.
+
+## Risks / Trade-offs
+
+- **[Bundle size]** → Monitor with `ls -la dist/feedtack.inject.js` after build. If over 20KB, audit what's being included. The capture logic is small; the UI DOM construction is the bulk.
+- **[CSP restrictions]** → Some sites block inline scripts or eval. The bookmarklet loader may be blocked by strict CSP. Mitigation: document this limitation, suggest the console paste method as fallback (which also won't work under strict CSP, but that's a known browser security boundary).
+- **[Clipboard API permissions]** → Modern browsers require HTTPS + user gesture for clipboard access. The submit button click provides the gesture. Non-HTTPS sites fall back to `document.execCommand('copy')`.
+- **[Shadow DOM browser support]** → Supported in all modern browsers. No IE11 support, which is acceptable.
+- **[sendBeacon payload limits]** → Browsers typically allow 64KB for sendBeacon. Feedtack payloads are well under this (~2-3KB).

--- a/openspec/changes/v0-6-0-injectable-snippet/design.md
+++ b/openspec/changes/v0-6-0-injectable-snippet/design.md
@@ -32,7 +32,7 @@ The snippet must be fully self-contained. All CSS is injected as inline styles o
 
 **Clipboard mode** (default): On submit, the payload JSON is copied to the clipboard via `navigator.clipboard.writeText()`. A toast confirms "Copied to clipboard." No server, no URL, no config. Falls back to `document.execCommand('copy')` if clipboard API is unavailable (non-HTTPS).
 
-**Webhook mode**: If a URL is provided at init time (`feedtack.inject({ url: '...' })`), payloads are sent via `navigator.sendBeacon(url, JSON.stringify(payload))`. sendBeacon is fire-and-forget, survives page unload, and doesn't block UI. Falls back to `fetch()` if sendBeacon is unavailable.
+**Webhook mode**: If a URL is provided at init time (`feedtack.inject({ url: '...' })`), payloads are sent via `navigator.sendBeacon(url, blob)` where `blob = new Blob([JSON.stringify(payload)], { type: 'application/json' })`. The Blob ensures the correct `Content-Type: application/json` header — without it, sendBeacon sends `text/plain` and most webhook receivers reject the payload. sendBeacon is fire-and-forget, survives page unload, and doesn't block UI. Falls back to `fetch()` with `keepalive: true` if sendBeacon is unavailable; the fetch fallback reports success/error based on response status.
 
 **Alternative considered:** LocalStorage queue with export. Rejected — data would live on someone else's domain and requires a separate export step.
 
@@ -50,7 +50,7 @@ For webhook mode, the bookmarklet sets a global config before loading:
 javascript:void((function(){window.__feedtack_config={url:'https://...'};var s=document.createElement('script');s.src='...';document.head.appendChild(s)})())
 ```
 
-The console paste version IS the full IIFE — no loader needed.
+The console paste version is a short loader script (same pattern as the bookmarklet but without the `javascript:` wrapper). The raw IIFE source is available as a secondary "offline" option for users who need to work without network access, but the default console snippet is the loader — pasting a 15-20KB minified blob is impractical in most browser consoles.
 
 ### 4. UI structure
 
@@ -70,11 +70,13 @@ The snippet creates a `<div id="feedtack-inject">` with an attached shadow root.
 - Feedtack styles from leaking into the host page
 - ID/class collisions
 
-### 6. Reuse capture code via build-time bundling
+### 6. Reuse capture code via build-time bundling — excluding fiber.ts
 
-The IIFE bundles `src/capture/target.ts` and `src/capture/meta.ts` at build time. These modules are already React-free. tsup bundles them into the IIFE alongside the inject-specific UI code.
+The IIFE bundles `src/capture/target.ts` and `src/capture/meta.ts` at build time. However, `target.ts` imports `getComponentName` from `fiber.ts`, which walks React fiber internals (`__reactFiber$`) and has a `'use client'` directive. This must be excluded from the IIFE.
 
-Verify: `src/capture/index.ts` barrel must not re-export anything that pulls in React. Currently exports `scanFields` and `hashField` from `content.ts` which uses Web Crypto — fine, but not needed for the snippet. The IIFE entry point imports directly from `target.ts` and `meta.ts`.
+**Approach:** Create `src/inject/target-shim.ts` that re-exports everything from `target.ts` but replaces the `getComponentName` import with a no-op that returns `null`. This keeps the capture code untouched for React users while giving the IIFE a clean dependency tree. The IIFE entry imports from the shim, not from `target.ts` directly.
+
+The IIFE entry point imports directly from `target-shim.ts` and `meta.ts` — never through `capture/index.ts` barrel.
 
 ### 7. Build configuration
 
@@ -93,10 +95,7 @@ New tsup entry point:
 
 Output: `dist/feedtack.inject.js`
 
-Package.json export:
-```json
-"./inject": { "default": "./dist/feedtack.inject.js" }
-```
+**No `package.json` export path.** The IIFE self-executes on load — adding it to the exports map would cause `import ... from 'feedtack/inject'` to immediately self-execute, which is dangerous in Node.js/SSR. The file is published in `dist/` and accessed via CDN URL or direct file reference only.
 
 ### 8. Snippet builder docs page
 
@@ -110,6 +109,28 @@ React component at `site-docs/content/docs/guides/snippet.mdx` with an interacti
 
 The component is a client-side React component in the docs site — it generates the bookmarklet/snippet strings dynamically based on user input.
 
+**URL sanitization:** The webhook URL input must be validated as a well-formed HTTPS URL before embedding in the bookmarklet `javascript:` href. Raw user input in a `javascript:` URL is an XSS vector (e.g., `'};alert(1);//` breaks out of the config string). Validate with `new URL()` and require `https:` protocol. Reject any URL that fails validation.
+
+**Version pinning:** The bookmarklet source URL defaults to the current feedtack version (e.g., `feedtack@1.2.0`), not `@latest`. This prevents saved bookmarklets from breaking when a new version ships. The builder shows the pinned version with an option to switch to `@latest`.
+
+### 9. User identity
+
+The snippet config accepts an optional `user` field: `feedtack.inject({ user: { id: 'u1', name: 'Alice', role: 'designer' } })`. If not provided, the payload uses `{ id: 'anon', name: 'Anonymous', role: 'reviewer' }`. The snippet UI includes an optional name input — if the user types a name, it overrides the config/default for `submittedBy.name`.
+
+The snippet builder docs page includes a user name input alongside the webhook URL.
+
+### 10. Payload ID generation
+
+The IIFE uses `crypto.randomUUID()` for payload IDs (prefixed with `ft_`). This is available in all modern browsers without additional dependencies. No nanoid dependency needed.
+
+### 11. Idempotency — double-injection guard
+
+On initialization, the IIFE checks for an existing `document.getElementById('feedtack-inject')` Shadow DOM host. If found, the second injection is a no-op (returns the existing instance). `feedtack.destroy()` removes the host, allowing re-injection.
+
+### 12. Touch / mobile support
+
+Pin mode listens for both `click` and `touchend` events. The trigger button uses `min-width: 44px; min-height: 44px` for touch targets. The panel uses `max-height: 80vh; overflow-y: auto` to fit small screens. No cursor change on touch devices (no cursor to change).
+
 ## Risks / Trade-offs
 
 - **[Bundle size]** → Monitor with `ls -la dist/feedtack.inject.js` after build. If over 20KB, audit what's being included. The capture logic is small; the UI DOM construction is the bulk.
@@ -117,3 +138,7 @@ The component is a client-side React component in the docs site — it generates
 - **[Clipboard API permissions]** → Modern browsers require HTTPS + user gesture for clipboard access. The submit button click provides the gesture. Non-HTTPS sites fall back to `document.execCommand('copy')`.
 - **[Shadow DOM browser support]** → Supported in all modern browsers. No IE11 support, which is acceptable.
 - **[sendBeacon payload limits]** → Browsers typically allow 64KB for sendBeacon. Feedtack payloads are well under this (~2-3KB).
+- **[CSP `style-src`]** → Shadow DOM `<style>` elements are still subject to the page's CSP `style-src` directive. Sites with `style-src 'self'` (no `'unsafe-inline'`) will block the injected styles, rendering the UI unstyled. Document this limitation — there is no workaround short of loading styles from an allowed origin.
+- **[sendBeacon delivery]** → sendBeacon returns a boolean (queued, not delivered). The toast shows "Sent" for sendBeacon (acknowledging fire-and-forget) and shows success/error for the fetch fallback which has a response status. Document that sendBeacon provides no delivery confirmation.
+- **[Pointer-events overlays]** → Cookie banners, modals, and loading overlays with `pointer-events: none` or full-screen z-index can intercept pin mode clicks. Document this limitation — the snippet captures whatever `e.target` resolves to.
+- **[RTL pages]** → The snippet UI forces `direction: ltr` inside the Shadow DOM to avoid inheriting RTL layout from the host page.

--- a/openspec/changes/v0-6-0-injectable-snippet/proposal.md
+++ b/openspec/changes/v0-6-0-injectable-snippet/proposal.md
@@ -8,9 +8,10 @@ Feedtack currently requires React integration and a build step. Users who want t
 - Two egress modes: clipboard (default, zero-config) and webhook (user provides a URL, uses `navigator.sendBeacon`)
 - Minimal vanilla JS UI: floating trigger button, pin mode with crosshair, scope selector, comment input, sentiment picker, submit
 - Same payload schema (`schemaVersion: "2.0.0"`) as the React version — payloads are interchangeable
-- Reuses existing capture logic (`src/capture/target.ts`, `src/capture/meta.ts`) bundled into the IIFE
-- Bookmarklet format: `javascript:void(...)` loader URL
-- Console paste format: raw IIFE source
+- Reuses existing capture logic (`src/capture/target.ts`, `src/capture/meta.ts`) bundled into the IIFE — with `fiber.ts` (React fiber walker) excluded, hardcoding `componentName: null`
+- Bookmarklet format: `javascript:void(...)` loader URL with version-pinned CDN source
+- Console paste format: short CDN loader script (with raw IIFE as secondary offline option)
+- User identity via config (`user: { id, name, role }`) or optional name input in the UI, defaulting to anonymous
 - New interactive docs page (`/docs/guides/snippet`) where users configure their webhook URL and get a generated bookmarklet link + copyable console snippet
 - New build target in `tsup.config.ts` producing `dist/feedtack.inject.js` (minified, self-contained)
 
@@ -28,6 +29,6 @@ Feedtack currently requires React integration and a build step. Users who want t
 - **New files**: `src/inject/` directory for standalone bundle source, `site-docs/` page + component for snippet builder
 - **Build**: New tsup entry point producing `dist/feedtack.inject.js`
 - **Capture code**: `src/capture/target.ts` and `src/capture/meta.ts` must be importable without pulling in React — verify no React imports leak into capture modules
-- **Package exports**: New `./inject` export path in `package.json` for the standalone bundle
+- **Package exports**: `dist/feedtack.inject.js` published in the package but NOT added to `package.json` exports map (IIFE self-executes on import — unsafe for ESM/SSR contexts)
 - **Bundle size target**: Under 20KB minified for the IIFE
 - **No breaking changes**: Existing React API and adapters are unchanged

--- a/openspec/changes/v0-6-0-injectable-snippet/proposal.md
+++ b/openspec/changes/v0-6-0-injectable-snippet/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+Feedtack currently requires React integration and a build step. Users who want to quickly audit a live site — QA testers, designers reviewing staging, stakeholders on a call — can't use feedtack without developer setup. A self-contained injectable snippet would let anyone paste a script into the browser console or click a bookmarklet to start leaving feedback on any page, with zero app integration.
+
+## What Changes
+
+- New standalone IIFE bundle (`feedtack.inject.js`) that self-initializes a minimal feedback UI on any page
+- Two egress modes: clipboard (default, zero-config) and webhook (user provides a URL, uses `navigator.sendBeacon`)
+- Minimal vanilla JS UI: floating trigger button, pin mode with crosshair, scope selector, comment input, sentiment picker, submit
+- Same payload schema (`schemaVersion: "2.0.0"`) as the React version — payloads are interchangeable
+- Reuses existing capture logic (`src/capture/target.ts`, `src/capture/meta.ts`) bundled into the IIFE
+- Bookmarklet format: `javascript:void(...)` loader URL
+- Console paste format: raw IIFE source
+- New interactive docs page (`/docs/guides/snippet`) where users configure their webhook URL and get a generated bookmarklet link + copyable console snippet
+- New build target in `tsup.config.ts` producing `dist/feedtack.inject.js` (minified, self-contained)
+
+## Capabilities
+
+### New Capabilities
+- `injectable-snippet`: Self-contained IIFE bundle with vanilla JS UI, capture logic, and egress (clipboard/webhook). No React, no build step, no app integration.
+- `snippet-builder`: Interactive docs page component that generates a configured bookmarklet URL and console snippet based on user inputs (webhook URL, options).
+
+### Modified Capabilities
+- `payload-schema`: No schema changes — the injectable snippet produces the same v2.0.0 payload. But the capture code paths need to be importable without React dependencies.
+
+## Impact
+
+- **New files**: `src/inject/` directory for standalone bundle source, `site-docs/` page + component for snippet builder
+- **Build**: New tsup entry point producing `dist/feedtack.inject.js`
+- **Capture code**: `src/capture/target.ts` and `src/capture/meta.ts` must be importable without pulling in React — verify no React imports leak into capture modules
+- **Package exports**: New `./inject` export path in `package.json` for the standalone bundle
+- **Bundle size target**: Under 20KB minified for the IIFE
+- **No breaking changes**: Existing React API and adapters are unchanged

--- a/openspec/changes/v0-6-0-injectable-snippet/specs/injectable-snippet/spec.md
+++ b/openspec/changes/v0-6-0-injectable-snippet/specs/injectable-snippet/spec.md
@@ -32,7 +32,8 @@ When a webhook URL is provided, the system SHALL send the payload to that URL on
 
 #### Scenario: Submit with webhook URL
 - **WHEN** a user submits feedback with a webhook URL configured via `feedtack.inject({ url: 'https://...' })`
-- **THEN** the payload is sent via `navigator.sendBeacon(url, JSON.stringify(payload))`
+- **THEN** the payload is sent via `navigator.sendBeacon(url, blob)` where `blob = new Blob([JSON.stringify(payload)], { type: 'application/json' })`
+- **AND** a toast message confirms "Sent"
 
 #### Scenario: sendBeacon fallback
 - **WHEN** `navigator.sendBeacon` is unavailable
@@ -49,6 +50,14 @@ The system SHALL accept configuration either as a function argument or via a glo
 - **WHEN** `window.__feedtack_config` is set before the script loads
 - **THEN** the snippet reads configuration from that global on initialization
 
+#### Scenario: User identity via config
+- **WHEN** the config includes `user: { id: 'u1', name: 'Alice', role: 'designer' }`
+- **THEN** the payload `submittedBy` field uses the provided user identity
+
+#### Scenario: Default anonymous identity
+- **WHEN** no `user` is provided in config
+- **THEN** the payload `submittedBy` uses `{ id: 'anon', name: 'Anonymous', role: 'reviewer' }`
+
 ### Requirement: Feedback UI
 The snippet SHALL provide a minimal UI for submitting feedback with scope selection, pin placement, comment, and sentiment.
 
@@ -56,9 +65,13 @@ The snippet SHALL provide a minimal UI for submitting feedback with scope select
 - **WHEN** the user clicks the floating trigger button
 - **THEN** a feedback panel opens with scope tabs (Site / Page / Element) and a comment textarea
 
-#### Scenario: Pin mode
-- **WHEN** the user clicks "Place a pin" in the panel
+#### Scenario: Pin mode (desktop)
+- **WHEN** the user clicks "Place a pin" in the panel on a desktop browser
 - **THEN** the cursor changes to a crosshair and clicking an element captures its target data and places a visual pin indicator
+
+#### Scenario: Pin mode (touch)
+- **WHEN** the user taps "Place a pin" in the panel on a mobile/touch device
+- **THEN** tapping an element captures its target data and places a visual pin indicator (no cursor change on touch devices)
 
 #### Scenario: Sentiment selection
 - **WHEN** the user selects a sentiment (good / bad / none)
@@ -82,11 +95,29 @@ The IIFE bundle SHALL be under 20KB minified.
 - **WHEN** `dist/feedtack.inject.js` is built with minification enabled
 - **THEN** the file size is under 20KB
 
+### Requirement: Idempotency
+The system SHALL handle double-injection gracefully.
+
+#### Scenario: Script loaded twice
+- **WHEN** the IIFE executes and a Shadow DOM host with `id="feedtack-inject"` already exists
+- **THEN** the second execution is a no-op and returns the existing instance
+
+#### Scenario: Re-injection after destroy
+- **WHEN** `feedtack.destroy()` has been called and the IIFE executes again
+- **THEN** a new instance initializes normally
+
+### Requirement: Payload ID generation
+The system SHALL generate unique payload IDs using `crypto.randomUUID()`.
+
+#### Scenario: ID format
+- **WHEN** a payload is assembled
+- **THEN** the `id` field is `'ft_' + crypto.randomUUID()`
+
 ### Requirement: Bookmarklet loader
 The system SHALL support loading via a bookmarklet URL.
 
-#### Scenario: Bookmarklet loads snippet from CDN
-- **WHEN** a user clicks a bookmarklet with `javascript:void(...)` that injects a script tag pointing to a CDN-hosted `feedtack.inject.js`
+#### Scenario: Bookmarklet loads snippet from CDN with pinned version
+- **WHEN** a user clicks a bookmarklet with `javascript:void(...)` that injects a script tag pointing to a version-pinned CDN URL (e.g., `feedtack@1.2.0`)
 - **THEN** the snippet loads and initializes on the current page
 
 #### Scenario: Bookmarklet with webhook config

--- a/openspec/changes/v0-6-0-injectable-snippet/specs/injectable-snippet/spec.md
+++ b/openspec/changes/v0-6-0-injectable-snippet/specs/injectable-snippet/spec.md
@@ -1,0 +1,94 @@
+## ADDED Requirements
+
+### Requirement: Self-initializing IIFE bundle
+The system SHALL produce a single `dist/feedtack.inject.js` file that, when executed in a browser context, initializes a feedback UI without any external dependencies or framework requirements.
+
+#### Scenario: Console paste initialization
+- **WHEN** a user pastes the IIFE source into a browser console and presses Enter
+- **THEN** a floating feedback trigger button appears in the bottom-right corner of the page
+
+#### Scenario: Script tag initialization
+- **WHEN** a `<script>` tag loads `feedtack.inject.js`
+- **THEN** the snippet self-initializes and the feedback UI appears
+
+#### Scenario: No conflict with host page
+- **WHEN** the snippet initializes on a page with existing CSS and JavaScript
+- **THEN** the snippet UI renders inside a Shadow DOM host element, preventing style leakage in either direction
+
+### Requirement: Clipboard egress mode (default)
+When no webhook URL is configured, the system SHALL copy the feedback payload JSON to the clipboard on submit.
+
+#### Scenario: Submit with clipboard mode
+- **WHEN** a user submits feedback without a webhook URL configured
+- **THEN** the payload JSON is copied to the clipboard via `navigator.clipboard.writeText()`
+- **AND** a toast message confirms "Copied to clipboard"
+
+#### Scenario: Clipboard fallback on non-HTTPS
+- **WHEN** the page is served over HTTP (not HTTPS) and `navigator.clipboard` is unavailable
+- **THEN** the system SHALL fall back to `document.execCommand('copy')`
+
+### Requirement: Webhook egress mode
+When a webhook URL is provided, the system SHALL send the payload to that URL on submit.
+
+#### Scenario: Submit with webhook URL
+- **WHEN** a user submits feedback with a webhook URL configured via `feedtack.inject({ url: 'https://...' })`
+- **THEN** the payload is sent via `navigator.sendBeacon(url, JSON.stringify(payload))`
+
+#### Scenario: sendBeacon fallback
+- **WHEN** `navigator.sendBeacon` is unavailable
+- **THEN** the system SHALL fall back to `fetch(url, { method: 'POST', body: JSON.stringify(payload), keepalive: true })`
+
+### Requirement: Configuration via global or argument
+The system SHALL accept configuration either as a function argument or via a global variable.
+
+#### Scenario: Configuration via function call
+- **WHEN** the IIFE exposes `feedtack.inject(config)` and the user calls it with `{ url: '...' }`
+- **THEN** the snippet uses the provided webhook URL for egress
+
+#### Scenario: Configuration via global variable
+- **WHEN** `window.__feedtack_config` is set before the script loads
+- **THEN** the snippet reads configuration from that global on initialization
+
+### Requirement: Feedback UI
+The snippet SHALL provide a minimal UI for submitting feedback with scope selection, pin placement, comment, and sentiment.
+
+#### Scenario: Open and close panel
+- **WHEN** the user clicks the floating trigger button
+- **THEN** a feedback panel opens with scope tabs (Site / Page / Element) and a comment textarea
+
+#### Scenario: Pin mode
+- **WHEN** the user clicks "Place a pin" in the panel
+- **THEN** the cursor changes to a crosshair and clicking an element captures its target data and places a visual pin indicator
+
+#### Scenario: Sentiment selection
+- **WHEN** the user selects a sentiment (good / bad / none)
+- **THEN** the payload includes the selected sentiment value
+
+#### Scenario: Submit and reset
+- **WHEN** the user clicks Submit with a comment entered
+- **THEN** the payload is emitted via the configured egress mode, the panel resets, and a confirmation toast appears
+
+### Requirement: Teardown
+The system SHALL provide a way to remove the injected UI and clean up event listeners.
+
+#### Scenario: Manual teardown
+- **WHEN** the user calls `feedtack.destroy()`
+- **THEN** the Shadow DOM host element is removed, all event listeners are detached, and no feedtack artifacts remain on the page
+
+### Requirement: Bundle size
+The IIFE bundle SHALL be under 20KB minified.
+
+#### Scenario: Size check
+- **WHEN** `dist/feedtack.inject.js` is built with minification enabled
+- **THEN** the file size is under 20KB
+
+### Requirement: Bookmarklet loader
+The system SHALL support loading via a bookmarklet URL.
+
+#### Scenario: Bookmarklet loads snippet from CDN
+- **WHEN** a user clicks a bookmarklet with `javascript:void(...)` that injects a script tag pointing to a CDN-hosted `feedtack.inject.js`
+- **THEN** the snippet loads and initializes on the current page
+
+#### Scenario: Bookmarklet with webhook config
+- **WHEN** the bookmarklet sets `window.__feedtack_config = { url: '...' }` before loading the script
+- **THEN** the snippet initializes in webhook mode with the configured URL

--- a/openspec/changes/v0-6-0-injectable-snippet/specs/payload-schema/spec.md
+++ b/openspec/changes/v0-6-0-injectable-snippet/specs/payload-schema/spec.md
@@ -1,0 +1,12 @@
+## MODIFIED Requirements
+
+### Requirement: Capture modules are React-free
+The capture modules (`src/capture/target.ts`, `src/capture/meta.ts`) SHALL have no direct or transitive imports of React or React DOM, ensuring they can be bundled into the standalone IIFE without pulling in framework dependencies.
+
+#### Scenario: Import tree verification
+- **WHEN** `src/capture/target.ts` and `src/capture/meta.ts` are analyzed for imports
+- **THEN** neither module imports from `react`, `react-dom`, or any module in `src/react/`
+
+#### Scenario: IIFE bundle contains no React
+- **WHEN** `dist/feedtack.inject.js` is built and its contents are searched
+- **THEN** no references to `react`, `React`, `createElement`, or `jsx` are found in the output

--- a/openspec/changes/v0-6-0-injectable-snippet/specs/payload-schema/spec.md
+++ b/openspec/changes/v0-6-0-injectable-snippet/specs/payload-schema/spec.md
@@ -1,12 +1,23 @@
 ## MODIFIED Requirements
 
-### Requirement: Capture modules are React-free
-The capture modules (`src/capture/target.ts`, `src/capture/meta.ts`) SHALL have no direct or transitive imports of React or React DOM, ensuring they can be bundled into the standalone IIFE without pulling in framework dependencies.
+### Requirement: IIFE capture path excludes React fiber walker
+The IIFE entry SHALL use a target shim that replaces `getComponentName` (from `fiber.ts`) with a no-op returning `null`. The existing `target.ts` import of `fiber.ts` SHALL remain unchanged for React users — only the IIFE build path is shimmed.
 
-#### Scenario: Import tree verification
-- **WHEN** `src/capture/target.ts` and `src/capture/meta.ts` are analyzed for imports
-- **THEN** neither module imports from `react`, `react-dom`, or any module in `src/react/`
+#### Scenario: Target shim excludes fiber.ts
+- **WHEN** `src/inject/target-shim.ts` is analyzed for imports
+- **THEN** it does NOT import from `fiber.ts` or any module containing `__reactFiber`
 
-#### Scenario: IIFE bundle contains no React
+#### Scenario: IIFE bundle contains no React artifacts
 - **WHEN** `dist/feedtack.inject.js` is built and its contents are searched
-- **THEN** no references to `react`, `React`, `createElement`, or `jsx` are found in the output
+- **THEN** no references to `react`, `React`, `createElement`, `jsx`, `__reactFiber`, or `'use client'` are found in the output
+
+#### Scenario: React users unaffected
+- **WHEN** the React version of feedtack imports from `src/capture/target.ts`
+- **THEN** `getComponentName` from `fiber.ts` is still called and populates `componentName` in the payload
+
+### Requirement: Payload componentName is null in snippet
+The IIFE-produced payloads SHALL set `target.componentName` to `null` for all captured elements (since no React fiber is available).
+
+#### Scenario: componentName in snippet payload
+- **WHEN** a pin is placed via the injectable snippet
+- **THEN** the `target` object in the payload has `componentName: null`

--- a/openspec/changes/v0-6-0-injectable-snippet/specs/snippet-builder/spec.md
+++ b/openspec/changes/v0-6-0-injectable-snippet/specs/snippet-builder/spec.md
@@ -1,0 +1,48 @@
+## ADDED Requirements
+
+### Requirement: Interactive snippet builder page
+The docs site SHALL include a guide page at `/docs/guides/snippet` with an interactive client component that generates configured feedtack snippets.
+
+#### Scenario: Page exists in docs navigation
+- **WHEN** a user navigates to the Guides section of the docs
+- **THEN** a "Snippet / Bookmarklet" page is listed and accessible
+
+### Requirement: Webhook URL input
+The builder component SHALL accept an optional webhook URL input.
+
+#### Scenario: No URL entered
+- **WHEN** the user leaves the webhook URL field empty
+- **THEN** the generated snippet uses clipboard mode (default)
+
+#### Scenario: URL entered
+- **WHEN** the user enters `https://hooks.example.com/feedtack` in the URL field
+- **THEN** the generated bookmarklet and console snippet include the webhook URL in the configuration
+
+### Requirement: Bookmarklet output
+The builder SHALL generate a draggable bookmarklet link.
+
+#### Scenario: Bookmarklet link rendered
+- **WHEN** the builder component renders (with or without a webhook URL)
+- **THEN** a styled `<a href="javascript:...">` link is displayed that the user can drag to their bookmarks bar
+
+#### Scenario: Bookmarklet includes config
+- **WHEN** the user has entered a webhook URL
+- **THEN** the bookmarklet `href` sets `window.__feedtack_config` with the URL before loading the script
+
+### Requirement: Console snippet output
+The builder SHALL generate a copyable console snippet.
+
+#### Scenario: Copy console snippet
+- **WHEN** the user clicks the copy button next to the console snippet
+- **THEN** the full IIFE source (or loader script with config) is copied to the clipboard
+
+#### Scenario: Snippet reflects configuration
+- **WHEN** the user changes the webhook URL input
+- **THEN** the console snippet updates in real time to reflect the new configuration
+
+### Requirement: Playwright route verification
+The snippet builder page SHALL be covered by the existing doc route verification tests.
+
+#### Scenario: Route resolves
+- **WHEN** the Playwright doc route tests run
+- **THEN** `/docs/guides/snippet` resolves with a 200 status (covered by meta.json + existing test infrastructure)

--- a/openspec/changes/v0-6-0-injectable-snippet/specs/snippet-builder/spec.md
+++ b/openspec/changes/v0-6-0-injectable-snippet/specs/snippet-builder/spec.md
@@ -40,6 +40,54 @@ The builder SHALL generate a copyable console snippet.
 - **WHEN** the user changes the webhook URL input
 - **THEN** the console snippet updates in real time to reflect the new configuration
 
+### Requirement: URL sanitization
+The builder SHALL validate webhook URLs before embedding them in generated snippets.
+
+#### Scenario: Valid HTTPS URL
+- **WHEN** the user enters `https://hooks.example.com/feedtack`
+- **THEN** the URL is accepted and embedded in the generated bookmarklet/snippet
+
+#### Scenario: Invalid URL rejected
+- **WHEN** the user enters a string that is not a valid URL (e.g., `'};alert(1);//`)
+- **THEN** the builder shows a validation error and does not generate a bookmarklet with the invalid input
+
+#### Scenario: Non-HTTPS URL rejected
+- **WHEN** the user enters an HTTP URL (e.g., `http://example.com/hook`)
+- **THEN** the builder shows a warning that HTTPS is required for webhook mode
+
+### Requirement: Version pinning
+The builder SHALL pin the CDN source URL to the current feedtack version by default.
+
+#### Scenario: Default version pinning
+- **WHEN** the builder generates a bookmarklet
+- **THEN** the CDN URL uses a pinned version (e.g., `feedtack@1.2.0`), not `@latest`
+
+#### Scenario: Latest version option
+- **WHEN** the user toggles a "use latest" option
+- **THEN** the CDN URL switches to `feedtack@latest`
+
+### Requirement: User identity input
+The builder SHALL include an optional user name input.
+
+#### Scenario: Name provided
+- **WHEN** the user enters a name in the identity input
+- **THEN** the generated snippet includes `user: { id: 'custom', name: '<entered name>', role: 'reviewer' }` in the config
+
+#### Scenario: Name omitted
+- **WHEN** the user leaves the identity input empty
+- **THEN** the generated snippet omits the `user` field (anonymous default)
+
+### Requirement: Console snippet as loader
+The builder SHALL generate a short CDN loader as the default console snippet.
+
+#### Scenario: Default console snippet is a loader
+- **WHEN** the builder generates a console snippet
+- **THEN** the snippet is a short loader that fetches from CDN (not the full minified IIFE)
+
+#### Scenario: Offline option
+- **WHEN** the user toggles an "offline / raw IIFE" option
+- **THEN** the console snippet shows the full IIFE source for paste-without-network use
+
 ### Requirement: Playwright route verification
 The snippet builder page SHALL be covered by the existing doc route verification tests.
 

--- a/openspec/changes/v0-6-0-injectable-snippet/tasks.md
+++ b/openspec/changes/v0-6-0-injectable-snippet/tasks.md
@@ -1,0 +1,53 @@
+## 1. Verify capture modules are React-free
+
+- [ ] 1.1 Audit `src/capture/target.ts` and `src/capture/meta.ts` import trees — confirm no React dependencies
+- [ ] 1.2 Audit `src/capture/index.ts` barrel — ensure IIFE entry can import `target` and `meta` without pulling in `content.ts` React-adjacent code
+
+## 2. Inject module structure
+
+- [ ] 2.1 Create `src/inject/index.ts` — IIFE entry point that reads `window.__feedtack_config`, calls `init(config)`, exposes `feedtack.inject()` and `feedtack.destroy()` on the global
+- [ ] 2.2 Create `src/inject/config.ts` — type definitions for inject config (`{ url?: string }`) and config resolution (global vs argument)
+- [ ] 2.3 Create `src/inject/egress.ts` — clipboard egress (clipboard API + execCommand fallback) and webhook egress (sendBeacon + fetch fallback)
+
+## 3. Inject UI (vanilla JS, Shadow DOM)
+
+- [ ] 3.1 Create `src/inject/ui.ts` — Shadow DOM host creation, style injection, trigger button rendering
+- [ ] 3.2 Create `src/inject/panel.ts` — feedback panel: scope tabs (site/page/element), comment textarea, sentiment buttons, submit button, pin mode button
+- [ ] 3.3 Create `src/inject/pin.ts` — crosshair cursor mode, element click handler, pin indicator placement, target capture using `src/capture/target.ts`
+- [ ] 3.4 Create `src/inject/toast.ts` — transient confirmation toast ("Copied to clipboard" / "Sent")
+- [ ] 3.5 Create `src/inject/styles.ts` — all CSS as a string constant, injected into Shadow DOM via `<style>` element
+
+## 4. Payload assembly
+
+- [ ] 4.1 Create `src/inject/payload.ts` — assembles `FeedtackPayload` (schemaVersion 2.0.0) from captured data (scope, comment, sentiment, pins, page meta, viewport, device)
+- [ ] 4.2 Wire submit flow: panel submit → payload assembly → egress → toast → reset
+
+## 5. Teardown
+
+- [ ] 5.1 Implement `feedtack.destroy()` — remove Shadow DOM host, detach all event listeners (pin mode, keyboard shortcuts), delete global references
+
+## 6. Build configuration
+
+- [ ] 6.1 Add IIFE entry to `tsup.config.ts` — entry `src/inject/index.ts`, format `iife`, globalName `feedtack`, minify, noExternal
+- [ ] 6.2 Add `"./inject"` export path to `package.json` pointing to `dist/feedtack.inject.js`
+- [ ] 6.3 Verify built bundle is under 20KB minified
+- [ ] 6.4 Verify built bundle contains no React references (`react`, `createElement`, `jsx`)
+
+## 7. Tests
+
+- [ ] 7.1 Unit tests for `src/inject/egress.ts` — clipboard write, sendBeacon call, fallbacks
+- [ ] 7.2 Unit tests for `src/inject/config.ts` — global config, argument config, merge behavior
+- [ ] 7.3 Unit tests for `src/inject/payload.ts` — payload structure matches schemaVersion 2.0.0
+- [ ] 7.4 Integration test: inject → submit → verify payload structure
+- [ ] 7.5 Build verification test: bundle size < 20KB, no React in output
+
+## 8. Snippet builder docs page
+
+- [ ] 8.1 Create `site-docs/content/docs/guides/snippet.mdx` — guide page with description and embedded interactive component
+- [ ] 8.2 Create `site-docs/src/components/SnippetBuilder.tsx` — client component: webhook URL input, mode toggle, generated bookmarklet `<a>` link, copyable console snippet code block
+- [ ] 8.3 Add `snippet` to `site-docs/content/docs/guides/meta.json` pages array
+- [ ] 8.4 Verify Playwright doc route test covers `/docs/guides/snippet`
+
+## 9. README
+
+- [ ] 9.1 Add "Injectable snippet" section to README — brief description, console paste example, bookmarklet example, link to docs guide

--- a/openspec/changes/v0-6-0-injectable-snippet/tasks.md
+++ b/openspec/changes/v0-6-0-injectable-snippet/tasks.md
@@ -1,53 +1,58 @@
-## 1. Verify capture modules are React-free
+## 1. Capture code isolation
 
-- [ ] 1.1 Audit `src/capture/target.ts` and `src/capture/meta.ts` import trees — confirm no React dependencies
-- [ ] 1.2 Audit `src/capture/index.ts` barrel — ensure IIFE entry can import `target` and `meta` without pulling in `content.ts` React-adjacent code
+- [ ] 1.1 Audit `src/capture/target.ts` import tree — confirm `fiber.ts` is the only React-adjacent dependency
+- [ ] 1.2 Create `src/inject/target-shim.ts` — re-exports `serializeNode` from `target.ts` but replaces `getComponentName` with a no-op returning `null`
+- [ ] 1.3 Verify `src/capture/meta.ts` has no React dependencies
 
 ## 2. Inject module structure
 
-- [ ] 2.1 Create `src/inject/index.ts` — IIFE entry point that reads `window.__feedtack_config`, calls `init(config)`, exposes `feedtack.inject()` and `feedtack.destroy()` on the global
-- [ ] 2.2 Create `src/inject/config.ts` — type definitions for inject config (`{ url?: string }`) and config resolution (global vs argument)
-- [ ] 2.3 Create `src/inject/egress.ts` — clipboard egress (clipboard API + execCommand fallback) and webhook egress (sendBeacon + fetch fallback)
+- [ ] 2.1 Create `src/inject/index.ts` — IIFE entry point: checks for existing instance (idempotency guard via `#feedtack-inject`), reads `window.__feedtack_config`, calls `init(config)`, exposes `feedtack.inject()` and `feedtack.destroy()` on the global
+- [ ] 2.2 Create `src/inject/config.ts` — config type (`{ url?: string, user?: { id: string, name: string, role: string } }`), config resolution (global → argument merge), default anonymous user (`{ id: 'anon', name: 'Anonymous', role: 'reviewer' }`)
+- [ ] 2.3 Create `src/inject/egress.ts` — clipboard egress (clipboard API + execCommand fallback), webhook egress (sendBeacon with `new Blob([json], { type: 'application/json' })` + fetch fallback with status reporting)
 
 ## 3. Inject UI (vanilla JS, Shadow DOM)
 
-- [ ] 3.1 Create `src/inject/ui.ts` — Shadow DOM host creation, style injection, trigger button rendering
-- [ ] 3.2 Create `src/inject/panel.ts` — feedback panel: scope tabs (site/page/element), comment textarea, sentiment buttons, submit button, pin mode button
-- [ ] 3.3 Create `src/inject/pin.ts` — crosshair cursor mode, element click handler, pin indicator placement, target capture using `src/capture/target.ts`
-- [ ] 3.4 Create `src/inject/toast.ts` — transient confirmation toast ("Copied to clipboard" / "Sent")
+- [ ] 3.1 Create `src/inject/ui.ts` — Shadow DOM host creation (`id="feedtack-inject"`), style injection, trigger button (44x44px min for touch targets), `direction: ltr` on shadow root
+- [ ] 3.2 Create `src/inject/panel.ts` — feedback panel: scope tabs (site/page/element), optional name input, comment textarea, sentiment buttons, submit button (with debounce), pin mode button; `max-height: 80vh; overflow-y: auto` for mobile
+- [ ] 3.3 Create `src/inject/pin.ts` — crosshair cursor mode (desktop), `click` + `touchend` event handlers, element click handler, pin indicator placement, target capture using `target-shim.ts`
+- [ ] 3.4 Create `src/inject/toast.ts` — transient confirmation toast ("Copied to clipboard" / "Sent" / error message for fetch fallback failures)
 - [ ] 3.5 Create `src/inject/styles.ts` — all CSS as a string constant, injected into Shadow DOM via `<style>` element
 
 ## 4. Payload assembly
 
-- [ ] 4.1 Create `src/inject/payload.ts` — assembles `FeedtackPayload` (schemaVersion 2.0.0) from captured data (scope, comment, sentiment, pins, page meta, viewport, device)
+- [ ] 4.1 Create `src/inject/payload.ts` — assembles `FeedtackPayload` (schemaVersion 2.0.0) from captured data: scope, comment, sentiment, pins (with `componentName: null`), page meta, viewport, device. ID via `'ft_' + crypto.randomUUID()`. `submittedBy` from config user or name input override.
 - [ ] 4.2 Wire submit flow: panel submit → payload assembly → egress → toast → reset
 
 ## 5. Teardown
 
-- [ ] 5.1 Implement `feedtack.destroy()` — remove Shadow DOM host, detach all event listeners (pin mode, keyboard shortcuts), delete global references
+- [ ] 5.1 Implement `feedtack.destroy()` — remove Shadow DOM host, detach all event listeners (pin mode, keyboard, touch), delete `window.feedtack` global, clear `window.__feedtack_config`
 
 ## 6. Build configuration
 
-- [ ] 6.1 Add IIFE entry to `tsup.config.ts` — entry `src/inject/index.ts`, format `iife`, globalName `feedtack`, minify, noExternal
-- [ ] 6.2 Add `"./inject"` export path to `package.json` pointing to `dist/feedtack.inject.js`
+- [ ] 6.1 Add IIFE entry to `tsup.config.ts` — entry `src/inject/index.ts`, format `iife`, globalName `feedtack`, minify, noExternal (bundle everything)
+- [ ] 6.2 Verify `dist/feedtack.inject.js` is published in the package but NOT added to `package.json` exports map (IIFE self-executes — unsafe for ESM/SSR import)
 - [ ] 6.3 Verify built bundle is under 20KB minified
-- [ ] 6.4 Verify built bundle contains no React references (`react`, `createElement`, `jsx`)
+- [ ] 6.4 Verify built bundle contains no React references (`react`, `createElement`, `jsx`, `__reactFiber`, `use client`)
 
 ## 7. Tests
 
-- [ ] 7.1 Unit tests for `src/inject/egress.ts` — clipboard write, sendBeacon call, fallbacks
-- [ ] 7.2 Unit tests for `src/inject/config.ts` — global config, argument config, merge behavior
-- [ ] 7.3 Unit tests for `src/inject/payload.ts` — payload structure matches schemaVersion 2.0.0
-- [ ] 7.4 Integration test: inject → submit → verify payload structure
-- [ ] 7.5 Build verification test: bundle size < 20KB, no React in output
+- [ ] 7.1 Unit tests for `src/inject/egress.ts` — clipboard write, sendBeacon with Blob Content-Type, fetch fallback with status, execCommand fallback
+- [ ] 7.2 Unit tests for `src/inject/config.ts` — global config, argument config, merge behavior, default anonymous user
+- [ ] 7.3 Unit tests for `src/inject/payload.ts` — payload structure matches schemaVersion 2.0.0, `submittedBy` from config, `componentName: null`, ID format `ft_<uuid>`
+- [ ] 7.4 Unit test for idempotency — second `inject()` call is a no-op when host exists, works after `destroy()`
+- [ ] 7.5 Unit test for `src/inject/target-shim.ts` — `componentName` is always `null`
+- [ ] 7.6 Build verification test: bundle size < 20KB, no React artifacts in output
+- [ ] 7.7 Integration test: inject → submit → verify payload structure and egress call
 
 ## 8. Snippet builder docs page
 
-- [ ] 8.1 Create `site-docs/content/docs/guides/snippet.mdx` — guide page with description and embedded interactive component
-- [ ] 8.2 Create `site-docs/src/components/SnippetBuilder.tsx` — client component: webhook URL input, mode toggle, generated bookmarklet `<a>` link, copyable console snippet code block
-- [ ] 8.3 Add `snippet` to `site-docs/content/docs/guides/meta.json` pages array
-- [ ] 8.4 Verify Playwright doc route test covers `/docs/guides/snippet`
+- [ ] 8.1 Create `site-docs/content/docs/guides/snippet.mdx` — guide page with description, limitations (CSP, pointer-events overlays, iframes), and embedded interactive component
+- [ ] 8.2 Create `site-docs/src/components/SnippetBuilder.tsx` — client component: webhook URL input (validated as HTTPS URL, XSS-safe), optional user name input, version pin toggle (default: pinned), loader/offline toggle for console snippet, generated bookmarklet `<a>` link, copyable console snippet code block
+- [ ] 8.3 Add URL sanitization — validate with `new URL()`, require `https:` protocol, show error on invalid input, never embed unsanitized input in `javascript:` href
+- [ ] 8.4 Add `snippet` to `site-docs/content/docs/guides/meta.json` pages array
+- [ ] 8.5 Verify Playwright doc route test covers `/docs/guides/snippet`
+- [ ] 8.6 Unit/integration test for SnippetBuilder — valid URL accepted, invalid URL rejected, XSS payload rejected, version pinning in output
 
 ## 9. README
 
-- [ ] 9.1 Add "Injectable snippet" section to README — brief description, console paste example, bookmarklet example, link to docs guide
+- [ ] 9.1 Add "Injectable snippet" section to README — brief description, console loader example, bookmarklet example, link to docs guide


### PR DESCRIPTION
## Summary

- OpenSpec proposal for a self-contained vanilla JS feedtack snippet — paste in console or use as a bookmarklet
- Two egress modes: clipboard (zero-config default) and webhook (`navigator.sendBeacon`)
- Shadow DOM isolation, same v2.0.0 payload schema as React version
- Interactive docs page where users generate their configured bookmarklet/snippet
- Bundle target: single IIFE file under 20KB minified

## Artifacts

- **proposal.md** — why: QA/designers/stakeholders can't use feedtack without dev setup
- **design.md** — how: IIFE + Shadow DOM + clipboard/sendBeacon egress + bookmarklet loader pattern
- **specs/** — 3 specs: injectable-snippet (8 requirements), snippet-builder (5 requirements), payload-schema (1 modified requirement for React-free capture)
- **tasks.md** — 25 implementation tasks across 9 groups

## Test plan

- [ ] CodeRabbit reviews spec completeness and design decisions
- [ ] Verify task coverage against spec requirements
- [ ] Review bundle size feasibility (<20KB for capture + vanilla UI)
- [ ] Review Shadow DOM isolation approach
- [ ] Review bookmarklet loader vs inline IIFE tradeoff

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced an injectable snippet feature that enables feedback collection on any webpage via console paste or bookmarklet.
  * Added dual submission modes: clipboard export (default) or webhook delivery.
  * Added an interactive snippet builder guide in documentation for generating and configuring snippets.

* **Documentation**
  * Added comprehensive design and specification documentation for the injectable snippet capability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->